### PR TITLE
feat: compute and display Rate of Rise (RoR)

### DIFF
--- a/packages/client/src/components/Chart.tsx
+++ b/packages/client/src/components/Chart.tsx
@@ -18,6 +18,8 @@ export interface ChartMarker {
 interface Props {
   points: ChartPoint[];
   markers?: ChartMarker[];
+  /** Rate of Rise values (°C/min) aligned 1:1 with `points`. `null` = gap. */
+  rorValues?: (number | null)[];
   /** Optional pixel height. Width follows the container. Default 320. */
   height?: number;
 }
@@ -31,12 +33,16 @@ const EVENT_COLOR: Record<RoastEvent, string> = {
   DROP: "#1f44d6",
 };
 
+/** RoR line color — warm orange, distinct from the dark BT line. */
+const ROR_COLOR = "#e07040";
+
 /**
- * Live + historical BT chart. Wraps uPlot. The component is "uncontrolled"
- * w.r.t. uPlot — we manage the instance via refs and feed it new data via
- * setData() rather than re-creating it on every prop change.
+ * Live + historical BT chart with optional RoR overlay. Wraps uPlot. The
+ * component is "uncontrolled" w.r.t. uPlot — we manage the instance via refs
+ * and feed it new data via setData() rather than re-creating it on every prop
+ * change.
  */
-export function Chart({ points, markers = [], height = 320 }: Props) {
+export function Chart({ points, markers = [], rorValues, height = 320 }: Props) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const plotRef = useRef<uPlot | null>(null);
   const markersRef = useRef<ChartMarker[]>(markers);
@@ -69,19 +75,49 @@ export function Chart({ points, markers = [], height = 320 }: Props) {
     const xs = points.map((p) => p.tSec);
     const ys = points.map((p) => p.btC);
 
+    // Build RoR data array for uPlot (use undefined for null gaps).
+    const hasRoR = rorValues && rorValues.length === points.length;
+    const rorData: (number | null | undefined)[] = hasRoR
+      ? rorValues.map((v) => (v === null ? undefined : v))
+      : xs.map(() => undefined);
+
     const opts: uPlot.Options = {
       width: el.clientWidth,
       height,
       scales: {
         x: { time: false },
+        ror: {
+          auto: true,
+          range: (_u, min, max) => {
+            // Give the RoR axis a little padding and a sane floor.
+            const lo = Math.min(min ?? 0, 0);
+            const hi = Math.max(max ?? 20, 5);
+            return [lo - 1, hi + 1];
+          },
+        },
       },
       axes: [
         { label: "time (s)" },
         { label: "BT (°C)" },
+        {
+          side: 1,       // right side
+          scale: "ror",
+          label: "RoR (°C/min)",
+          stroke: ROR_COLOR,
+          grid: { show: false },
+        },
       ],
       series: [
         {}, // x
         { label: "BT", stroke: "#222", width: 2 },
+        {
+          label: "RoR",
+          stroke: ROR_COLOR,
+          width: 1.5,
+          scale: "ror",
+          dash: [6, 3],
+          spanGaps: false,
+        },
       ],
       hooks: {
         draw: [
@@ -111,14 +147,14 @@ export function Chart({ points, markers = [], height = 320 }: Props) {
     if (plotRef.current) {
       plotRef.current.destroy();
     }
-    const plot = new uPlot(opts, [xs, ys], el);
+    const plot = new uPlot(opts, [xs, ys, rorData as number[]], el);
     plotRef.current = plot;
 
     return () => {
       plot.destroy();
       if (plotRef.current === plot) plotRef.current = null;
     };
-  }, [points, height]);
+  }, [points, rorValues, height]);
 
   return <div ref={containerRef} style={{ width: "100%", height }} />;
 }

--- a/packages/client/src/pages/RoastDetailPage.tsx
+++ b/packages/client/src/pages/RoastDetailPage.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import { api, type RoastDetail } from "../api.ts";
 import { Chart, type ChartPoint, type ChartMarker } from "../components/Chart.tsx";
+import { computeRoR } from "../ror.ts";
 
 export function RoastDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -26,18 +27,28 @@ export function RoastDetailPage() {
     };
   }, [id]);
 
+  const points: ChartPoint[] = useMemo(() => {
+    if (!detail) return [];
+    return detail.readings.map((r) => ({
+      tSec: r.tMs / 1000,
+      btC: r.btC,
+    }));
+  }, [detail]);
+
+  const markers: ChartMarker[] = useMemo(() => {
+    if (!detail) return [];
+    return detail.events.map((e) => ({
+      tSec: (e.ts - detail.roast.chargeTs) / 1000,
+      event: e.event,
+    }));
+  }, [detail]);
+
+  // Compute RoR once from persisted readings.
+  const rorValues = useMemo(() => computeRoR(points), [points]);
+
   if (!id) return <div className="error">Missing roast id.</div>;
   if (error) return <div className="error">Failed to load roast: {error}</div>;
   if (detail === null) return <div className="muted">Loading…</div>;
-
-  const points: ChartPoint[] = detail.readings.map((r) => ({
-    tSec: r.tMs / 1000,
-    btC: r.btC,
-  }));
-  const markers: ChartMarker[] = detail.events.map((e) => ({
-    tSec: (e.ts - detail.roast.chargeTs) / 1000,
-    event: e.event,
-  }));
 
   return (
     <div className="roast-detail">
@@ -51,7 +62,7 @@ export function RoastDetailPage() {
         </div>
         <Link to="/roasts" className="roast-detail__back">← Back to history</Link>
       </header>
-      <Chart points={points} markers={markers} />
+      <Chart points={points} markers={markers} rorValues={rorValues} />
       <ul className="roast-detail__events">
         {detail.events.map((e) => (
           <li key={e.id}>

--- a/packages/client/src/pages/RoastPage.tsx
+++ b/packages/client/src/pages/RoastPage.tsx
@@ -3,6 +3,7 @@ import type { RoastEvent } from "@starmaya/shared";
 import { useStream } from "../hooks/useStream.ts";
 import { Chart, type ChartPoint, type ChartMarker } from "../components/Chart.tsx";
 import { api } from "../api.ts";
+import { computeRoR } from "../ror.ts";
 
 /** Events that go through the generic events endpoint (not CHARGE or DROP). */
 const MID_ROAST_EVENTS: RoastEvent[] = ["DRY_END", "FC_START", "FC_END"];
@@ -35,6 +36,17 @@ export function RoastPage() {
       event: e.event,
     }));
   }, [stream.events, active]);
+
+  // Compute Rate of Rise from the chart points.
+  const rorValues = useMemo(() => computeRoR(chartPoints), [chartPoints]);
+
+  // Latest non-null RoR value for the numeric readout.
+  const currentRoR = useMemo(() => {
+    for (let i = rorValues.length - 1; i >= 0; i--) {
+      if (rorValues[i] !== null) return rorValues[i];
+    }
+    return null;
+  }, [rorValues]);
 
   const elapsedSec = active && stream.lastTick
     ? Math.max(0, (stream.lastTick.ts - active.chargeTs) / 1000)
@@ -104,8 +116,15 @@ export function RoastPage() {
   return (
     <div className="roast-page">
       <section className="readout">
-        <div className="readout__bt">
-          {stream.lastTick ? `${stream.lastTick.btC.toFixed(1)}°C` : "—"}
+        <div className="readout__temps">
+          <div className="readout__bt">
+            {stream.lastTick ? `${stream.lastTick.btC.toFixed(1)}°C` : "—"}
+          </div>
+          {active && (
+            <div className="readout__ror">
+              {currentRoR !== null ? `↑ ${currentRoR.toFixed(1)} °C/min` : "—"}
+            </div>
+          )}
         </div>
         <div className="readout__meta">
           <span className={`status status--${stream.deviceStatus}`}>
@@ -164,7 +183,7 @@ export function RoastPage() {
       </section>
 
       <section className="chart-section">
-        <Chart points={chartPoints} markers={chartMarkers} />
+        <Chart points={chartPoints} markers={chartMarkers} rorValues={rorValues} />
       </section>
     </div>
   );

--- a/packages/client/src/ror.ts
+++ b/packages/client/src/ror.ts
@@ -1,0 +1,69 @@
+/**
+ * Rate of Rise (RoR) computation.
+ *
+ * RoR is the smoothed time-derivative of bean temperature, expressed as °C/min.
+ * We use a centered moving-average derivative: for each point, we look at the
+ * temperature change over a symmetric time window and convert to per-minute.
+ *
+ * A centered window avoids the visible phase-lag of a trailing-only SMA while
+ * still providing effective noise smoothing at typical ~2s polling intervals.
+ */
+
+export interface RoRPoint {
+  tSec: number;
+  btC: number;
+}
+
+/** Minimum time span (seconds) within the window to produce a value. */
+const MIN_SPAN_SEC = 3;
+
+/**
+ * Compute Rate of Rise for each point in `points`.
+ *
+ * @param points  Chronologically ordered `{tSec, btC}` readings.
+ * @param windowSec  Symmetric window size in seconds (default 30). The window
+ *   extends ±windowSec/2 around each point.
+ * @returns An array aligned 1:1 with `points`. Each entry is the RoR in °C/min
+ *   or `null` if there isn't enough data in the window.
+ */
+export function computeRoR(
+  points: readonly RoRPoint[],
+  windowSec = 30,
+): (number | null)[] {
+  const n = points.length;
+  if (n < 2) return points.map(() => null);
+
+  const halfWindow = windowSec / 2;
+  const result: (number | null)[] = new Array(n);
+
+  // Two-pointer sweep: maintain [lo, hi) as the window around each center point.
+  let lo = 0;
+  let hi = 0;
+
+  for (let i = 0; i < n; i++) {
+    const center = points[i].tSec;
+    const wStart = center - halfWindow;
+    const wEnd = center + halfWindow;
+
+    // Advance lo to the first point inside the window.
+    while (lo < n && points[lo].tSec < wStart) lo++;
+    // Advance hi to just past the last point inside the window.
+    while (hi < n && points[hi].tSec <= wEnd) hi++;
+
+    // hi is exclusive, so the window indices are [lo, hi - 1].
+    const first = lo;
+    const last = hi - 1;
+
+    const span = points[last].tSec - points[first].tSec;
+
+    if (last <= first || span < MIN_SPAN_SEC) {
+      result[i] = null;
+    } else {
+      const deltaC = points[last].btC - points[first].btC;
+      // Convert from °C/sec to °C/min.
+      result[i] = (deltaC / span) * 60;
+    }
+  }
+
+  return result;
+}

--- a/packages/client/src/styles.css
+++ b/packages/client/src/styles.css
@@ -74,11 +74,24 @@ input {
   margin-bottom: 1rem;
 }
 
+.readout__temps {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
 .readout__bt {
   font-size: 4rem;
   font-weight: 300;
   font-variant-numeric: tabular-nums;
   line-height: 1;
+}
+
+.readout__ror {
+  font-size: 1.25rem;
+  font-variant-numeric: tabular-nums;
+  color: #e07040;
+  font-weight: 500;
 }
 
 .readout__meta {


### PR DESCRIPTION
## Summary

Closes #1. Adds client-side Rate of Rise (RoR) computation and display — the most-used analytical signal in coffee roasting.

## What changed

### New file: `packages/client/src/ror.ts`
Pure RoR computation utility using a **centered moving-average derivative** over a 30-second window. The algorithm uses an O(n) two-pointer sweep rather than nested loops. For each point, it looks at the BT change across a symmetric time window and converts to °C/min.

- Returns `null` where the window contains insufficient data (fewer than 2 points or <3s span), which naturally covers the first/last ~15s of a roast.
- Centered (vs trailing) windowing avoids the visible phase-lag that a trailing-only SMA introduces.

### Modified: `Chart.tsx`
- Accepts an optional `rorValues?: (number | null)[]` prop aligned 1:1 with `points`.
- Adds a **second y-axis** on the right side for RoR (°C/min).
- Adds a **dashed orange RoR line** (`#e07040`) as a second series bound to the RoR scale.
- RoR axis auto-scales with padding and a sensible floor.

### Modified: `RoastPage.tsx`
- Computes RoR from `chartPoints` via `useMemo`.
- Passes `rorValues` to `<Chart>`.
- Adds a **numeric RoR readout** below the BT display (e.g., "↑ 5.2 °C/min"), showing the latest non-null value. Shows "—" while insufficient data has accumulated.
- Wrapped BT + RoR readouts in a `.readout__temps` container for layout.

### Modified: `RoastDetailPage.tsx`
- Computes RoR once from persisted readings via `useMemo`.
- Passes `rorValues` to `<Chart>` so historical roasts also show the RoR curve.
- Wrapped point/marker computation in `useMemo` (minor cleanup).

### Modified: `styles.css`
- Added `.readout__temps` flex container.
- Added `.readout__ror` styling — warm orange color matching the chart line, tabular-nums, smaller than BT.

## Design decisions
- **30s centered window** — matches the issue recommendation. No configurable presets (deferred per issue).
- **No server/daemon changes** — RoR is computed entirely client-side from the existing tick/readings data.
- **`null` gaps in chart** — uPlot natively handles gaps, so the RoR line simply doesn't draw where data is insufficient.

## Verification
- `pnpm --filter @starmaya/client run build` passes ✅