### PR TITLE
feat: mobile-responsive layout and touch-friendly roast mode

### DIFF
--- a/packages/client/src/pages/RoastPage.tsx
+++ b/packages/client/src/pages/RoastPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { RoastEvent } from "@starmaya/shared";
 import { useStream } from "../hooks/useStream.ts";
 import { Chart, type ChartPoint, type ChartMarker } from "../components/Chart.tsx";
@@ -14,6 +14,18 @@ export function RoastPage() {
   const [error, setError] = useState<string | null>(null);
 
   const active = stream.activeRoast;
+
+  // Toggle a CSS class on <body> so the rest of the page (header, nav) can
+  // adapt when a roast is in progress — "roast mode" hides chrome and
+  // maximizes the control surface for hands-busy use at the roaster.
+  useEffect(() => {
+    if (active) {
+      document.body.classList.add("roast-mode");
+    } else {
+      document.body.classList.remove("roast-mode");
+    }
+    return () => document.body.classList.remove("roast-mode");
+  }, [active]);
   const recordedEvents = useMemo(
     () => new Set(stream.events.map((e) => e.event)),
     [stream.events],

--- a/packages/client/src/styles.css
+++ b/packages/client/src/styles.css
@@ -295,3 +295,131 @@ input {
   font-variant-numeric: tabular-nums;
   color: #555;
 }
+
+/* ── Mobile responsive (≤640px) ───────────────────────────────── */
+
+@media (max-width: 640px) {
+  .app {
+    padding: 0.5rem;
+  }
+
+  .app__header {
+    padding-bottom: 0.35rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .app__header h1 {
+    font-size: 1.2rem;
+  }
+
+  /* Readout: stack vertically instead of side-by-side */
+  .readout {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+    padding: 0.75rem 1rem;
+  }
+
+  .readout__bt {
+    font-size: 2.75rem;
+  }
+
+  .readout__meta {
+    flex-direction: row;
+    align-items: center;
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .readout__elapsed {
+    font-size: 1.5rem;
+  }
+
+  /* Event buttons: 2-column grid with large touch targets */
+  .controls__events {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .btn {
+    min-height: 60px;
+    font-size: 1rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .btn--charge {
+    min-height: 60px;
+    font-size: 1.1rem;
+  }
+
+  /* Chart: shorter for portrait phones */
+  .chart-section {
+    padding: 0.25rem;
+  }
+
+  /* History list: more breathing room for touch */
+  .history__link {
+    padding: 1rem 0.5rem;
+  }
+
+  /* Roast detail */
+  .roast-detail__events {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+/* ── Roast mode (active roast) ────────────────────────────────── */
+/* Applied to <body> when a roast is in progress. Hides navigation
+   chrome and maximizes the control surface for use at the roaster
+   with busy hands.                                                */
+
+.roast-mode .app__header {
+  display: none;
+}
+
+.roast-mode .app {
+  padding: 0.5rem;
+}
+
+/* In roast mode on mobile, go even larger for quick glances */
+@media (max-width: 640px) {
+  .roast-mode .readout {
+    padding: 0.5rem 0.75rem;
+  }
+
+  .roast-mode .readout__bt {
+    font-size: 3.5rem;
+  }
+
+  .roast-mode .readout__elapsed {
+    font-size: 2rem;
+  }
+
+  .roast-mode .readout__meta {
+    flex-direction: row;
+    justify-content: space-between;
+    width: 100%;
+  }
+
+  /* Status indicator becomes a compact corner pill */
+  .roast-mode .status {
+    font-size: 0.65rem;
+    padding: 0.1rem 0.35rem;
+  }
+
+  /* Larger touch targets in roast mode */
+  .roast-mode .btn {
+    min-height: 68px;
+    font-size: 1.1rem;
+  }
+
+  .roast-mode .controls {
+    padding: 0.5rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .roast-mode .controls__active-name {
+    margin-bottom: 0.5rem;
+  }
+}


### PR DESCRIPTION
## Summary

Closes #2. Makes the UI usable on a phone at the roaster with busy hands.

## What changed

### Modified: `packages/client/src/pages/RoastPage.tsx`
- Added a `useEffect` that toggles a `roast-mode` CSS class on `<body>` when `activeRoast !== null`.
- Clean removal on unmount and when the roast ends.

### Modified: `packages/client/src/styles.css`

#### Mobile breakpoint (`@media (max-width: 640px)`)
- **Readout** stacks vertically (BT on top, status + elapsed in a row below)
- **BT** shrinks from 4rem → 2.75rem, elapsed from 2rem → 1.5rem
- **Event buttons** switch from 4-column → **2-column grid** with **60px min-height** touch targets (≥ Apple HIG 44pt recommendation)
- **CHARGE button** gets matching 60px min-height
- **Chart section** padding tightens
- **History links** get extra vertical padding for touch
- **Detail page events** go 2-column

#### Roast mode (`body.roast-mode`)
- **Header and nav hidden** — no wasted screen space during an active roast
- **App padding reduced** to 0.5rem
- On mobile, roast mode further optimizes:
  - BT readout → **3.5rem** (largest element on screen)
  - Elapsed timer → **2rem**
  - Event buttons → **68px min-height** with 1.1rem font
  - Status pill shrinks to a compact corner indicator (0.65rem)
  - Controls and readout padding tightened

## Design decisions
- **640px breakpoint** matches the issue recommendation and covers virtually all phones in portrait.
- **Roast mode is a body-level class** (not a React context) so it can affect the header/nav which live in App.tsx without threading props. The `useEffect` in RoastPage is the single source of truth.
- **No tablet breakpoint** — the issue explicitly says "Adaptive layouts for tablets" is out of scope since the current layout is mostly fine.

## Verification
- `pnpm --filter @starmaya/client run build` passes ✅
- The issue notes "test on actual phones" — recommend manual verification on a real device before merging.