### PR TITLE
feat(daemon): decouple serial poller from hardware protocol

### DIFF
--- a/packages/daemon/src/adapters/tc4-arduino.ts
+++ b/packages/daemon/src/adapters/tc4-arduino.ts
@@ -1,0 +1,72 @@
+import type { DeviceAdapter, ParseResult } from "./types.js";
+
+/**
+ * Configuration knobs the TC4 adapter needs at construction time. The shape
+ * is intentionally a strict subset of `DaemonConfig` field names so that the
+ * full config can be passed in directly by structural typing.
+ */
+export interface TC4ArduinoAdapterConfig {
+  /** Lower bound (°C) below which BT readings are flagged as `bt_out_of_range`. */
+  btMinPlausibleC: number;
+  /** Upper bound (°C) above which BT readings are flagged as `bt_out_of_range`. */
+  btMaxPlausibleC: number;
+}
+
+/**
+ * Adapter for the TC4-style Arduino + MAX31855 + K-type-thermocouple rig.
+ *
+ * Protocol summary:
+ *
+ *   - Request/response over USB-serial at 115200 baud.
+ *   - Host writes `READ\r\n` to request a sample.
+ *   - Device replies with a single CRLF-terminated CSV line:
+ *
+ *       `<ambient_c>,<bt_c>[,<et_c>]`
+ *
+ *     where the BT field may carry one of the MAX31855 fault sentinels:
+ *
+ *       -1 → open circuit       (no thermocouple connected)
+ *       -2 → short to ground
+ *       -3 → short to VCC
+ *
+ *   - Anything else with fewer than 2 CSV fields is treated as malformed
+ *     and silently ignored by the poller.
+ */
+export class TC4ArduinoAdapter implements DeviceAdapter {
+  readonly mode = "request-response" as const;
+
+  constructor(private readonly cfg: TC4ArduinoAdapterConfig) {}
+
+  getPollCommand(): string {
+    return "READ\r\n";
+  }
+
+  parse(data: string | Buffer): ParseResult | null {
+    const line = typeof data === "string" ? data : data.toString("utf-8");
+    const fields = line.trim().split(",");
+    if (fields.length < 2) return null;
+
+    const btRaw = parseFloat(fields[1]!);
+    const fault = classifyBtFault(btRaw, this.cfg);
+    if (fault) {
+      return { kind: "fault", raw: line, reason: fault };
+    }
+
+    const etRaw = fields[2] !== undefined ? parseFloat(fields[2]) : NaN;
+    const etC = Number.isFinite(etRaw) ? etRaw : null;
+    return { kind: "reading", bt_c: btRaw, et_c: etC };
+  }
+}
+
+/**
+ * Classify a BT value against MAX31855 error codes and the configured
+ * plausibility range. Returns a fault reason or null if the value is OK.
+ */
+function classifyBtFault(bt: number, cfg: TC4ArduinoAdapterConfig): string | null {
+  if (Number.isNaN(bt)) return "bt_nan";
+  if (bt === -1) return "bt_open_circuit";
+  if (bt === -2) return "bt_short_gnd";
+  if (bt === -3) return "bt_short_vcc";
+  if (bt < cfg.btMinPlausibleC || bt > cfg.btMaxPlausibleC) return "bt_out_of_range";
+  return null;
+}

--- a/packages/daemon/src/adapters/tc4-arduino.ts
+++ b/packages/daemon/src/adapters/tc4-arduino.ts
@@ -1,4 +1,4 @@
-import type { DeviceAdapter, ParseResult } from "./types.js";
+import type { RequestResponseDeviceAdapter, ParseResult } from "./types.js";
 
 /**
  * Configuration knobs the TC4 adapter needs at construction time. The shape
@@ -32,7 +32,7 @@ export interface TC4ArduinoAdapterConfig {
  *   - Anything else with fewer than 2 CSV fields is treated as malformed
  *     and silently ignored by the poller.
  */
-export class TC4ArduinoAdapter implements DeviceAdapter {
+export class TC4ArduinoAdapter implements RequestResponseDeviceAdapter {
   readonly mode = "request-response" as const;
 
   constructor(private readonly cfg: TC4ArduinoAdapterConfig) {}

--- a/packages/daemon/src/adapters/types.ts
+++ b/packages/daemon/src/adapters/types.ts
@@ -1,0 +1,71 @@
+import type { ReadingMessage, SensorFaultMessage } from "@starmaya/shared";
+
+/**
+ * Contract between the protocol-agnostic serial poller and a hardware-specific
+ * device implementation.
+ *
+ * Ownership boundary:
+ *
+ *   - The poller owns: serial port lifecycle, reconnect, post-open delay,
+ *     timing, event emission.
+ *   - The adapter owns: polling commands, response parsing, sensor
+ *     interpretation, hardware quirks that need to run after the port opens.
+ *
+ * Two interaction modes are supported:
+ *
+ *   - `"request-response"` — the poller periodically calls
+ *     `getPollCommand()` and writes the result to the port. Each device
+ *     reply arrives as a single line which the poller feeds back to
+ *     `parse()`.
+ *
+ *   - `"streaming"` — the device emits lines on its own cadence. The poller
+ *     never writes polling commands; it simply forwards every received line
+ *     to `parse()`.
+ */
+export interface DeviceAdapter {
+  /** Selects whether the poller writes polling commands or only reads. */
+  readonly mode: "request-response" | "streaming";
+
+  /**
+   * Called once after the serial port has opened and the poller's
+   * `postOpenDelayMs` has elapsed. Use for any device-specific handshake
+   * (e.g. configuring sample rate, requesting a banner). Optional; absent
+   * means no handshake is required.
+   */
+  onPortOpened?(): Promise<void>;
+
+  /**
+   * Returns the bytes (or string) to write to the port on each poll. Only
+   * called when `mode === "request-response"`. Must be defined when in that
+   * mode.
+   */
+  getPollCommand?(): string | Buffer;
+
+  /**
+   * Parse a single line of input from the device.
+   *
+   * Return `null` to silently ignore malformed input — the poller will not
+   * emit anything for that line. Throw only on truly unexpected adapter
+   * bugs; transport-level failures are the poller's concern.
+   *
+   * The returned object carries only the device-supplied fields. The poller
+   * attaches `type` and `ts` before emission to keep timestamp ownership in
+   * one place.
+   */
+  parse(data: string | Buffer): ParseResult | null;
+}
+
+/** Discriminated union of what an adapter can produce from a single line. */
+export type ParseResult = ReadingParse | FaultParse;
+
+export interface ReadingParse {
+  kind: "reading";
+  bt_c: ReadingMessage["bt_c"];
+  et_c: ReadingMessage["et_c"];
+}
+
+export interface FaultParse {
+  kind: "fault";
+  raw: SensorFaultMessage["raw"];
+  reason: SensorFaultMessage["reason"];
+}

--- a/packages/daemon/src/adapters/types.ts
+++ b/packages/daemon/src/adapters/types.ts
@@ -22,10 +22,10 @@ import type { ReadingMessage, SensorFaultMessage } from "@starmaya/shared";
  *     never writes polling commands; it simply forwards every received line
  *     to `parse()`.
  */
-export interface DeviceAdapter {
-  /** Selects whether the poller writes polling commands or only reads. */
-  readonly mode: "request-response" | "streaming";
-
+/**
+ * Fields common to every adapter regardless of interaction mode.
+ */
+interface BaseDeviceAdapter {
   /**
    * Called once after the serial port has opened and the poller's
    * `postOpenDelayMs` has elapsed. Use for any device-specific handshake
@@ -33,13 +33,6 @@ export interface DeviceAdapter {
    * means no handshake is required.
    */
   onPortOpened?(): Promise<void>;
-
-  /**
-   * Returns the bytes (or string) to write to the port on each poll. Only
-   * called when `mode === "request-response"`. Must be defined when in that
-   * mode.
-   */
-  getPollCommand?(): string | Buffer;
 
   /**
    * Parse a single line of input from the device.
@@ -54,6 +47,27 @@ export interface DeviceAdapter {
    */
   parse(data: string | Buffer): ParseResult | null;
 }
+
+/**
+ * Adapter for devices the host has to actively poll. The poller writes
+ * `getPollCommand()` on each tick and waits for one line in response.
+ */
+export interface RequestResponseDeviceAdapter extends BaseDeviceAdapter {
+  readonly mode: "request-response";
+  /** Bytes (or string) to write to the port on each poll. */
+  getPollCommand(): string | Buffer;
+}
+
+/**
+ * Adapter for devices that emit lines on their own cadence. The poller
+ * never writes polling commands; every received line is forwarded to
+ * `parse()` directly.
+ */
+export interface StreamingDeviceAdapter extends BaseDeviceAdapter {
+  readonly mode: "streaming";
+}
+
+export type DeviceAdapter = RequestResponseDeviceAdapter | StreamingDeviceAdapter;
 
 /** Discriminated union of what an adapter can produce from a single line. */
 export type ParseResult = ReadingParse | FaultParse;

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -1,5 +1,11 @@
 import { readFileSync } from "node:fs";
 
+/**
+ * Hardware adapter to instantiate at startup. Extend this union and the
+ * `makeAdapter` switch in main.ts when adding new device support.
+ */
+export type DeviceProfile = "tc4";
+
 /** Resolved daemon configuration. */
 export interface DaemonConfig {
   socketPath: string;
@@ -20,6 +26,8 @@ export interface DaemonConfig {
   postOpenDelayMs: number;
   btMinPlausibleC: number;
   btMaxPlausibleC: number;
+  /** Selects which hardware adapter the daemon instantiates. */
+  deviceProfile: DeviceProfile;
   /** If true, generate a synthetic temperature curve instead of opening the serial port. */
   mockSerial: boolean;
 }
@@ -36,6 +44,7 @@ const DEFAULTS: DaemonConfig = {
   postOpenDelayMs: 2500,
   btMinPlausibleC: -50,
   btMaxPlausibleC: 500,
+  deviceProfile: "tc4",
   mockSerial: false,
 };
 

--- a/packages/daemon/src/main.ts
+++ b/packages/daemon/src/main.ts
@@ -3,6 +3,7 @@ import { loadConfig, type DaemonConfig } from "./config.js";
 import { SerialPoller } from "./serial-poller.js";
 import { MockSerialPoller } from "./mock-serial-poller.js";
 import { SocketServer, type ReadingSource } from "./socket-server.js";
+import type { DeviceAdapter } from "./adapters/types.js";
 import { TC4ArduinoAdapter } from "./adapters/tc4-arduino.js";
 
 interface CliArgs {
@@ -38,6 +39,22 @@ function makeLogger() {
   };
 }
 
+/**
+ * Instantiate the configured hardware adapter. Extend this switch when
+ * adding new device support; the `never` default makes missing cases a
+ * compile-time error.
+ */
+function makeAdapter(cfg: DaemonConfig): DeviceAdapter {
+  switch (cfg.deviceProfile) {
+    case "tc4":
+      return new TC4ArduinoAdapter(cfg);
+    default: {
+      const _exhaustive: never = cfg.deviceProfile;
+      throw new Error(`Unknown deviceProfile: ${String(_exhaustive)}`);
+    }
+  }
+}
+
 function makeSource(cfg: DaemonConfig, log: ReturnType<typeof makeLogger>): ReadingSource & {
   start(): void;
   stop(): void;
@@ -46,7 +63,8 @@ function makeSource(cfg: DaemonConfig, log: ReturnType<typeof makeLogger>): Read
     log("info", "using_mock_serial", {});
     return new MockSerialPoller(cfg, log);
   }
-  const adapter = new TC4ArduinoAdapter(cfg);
+  const adapter = makeAdapter(cfg);
+  log("info", "device_adapter_selected", { profile: cfg.deviceProfile });
   return new SerialPoller(cfg, adapter, log);
 }
 

--- a/packages/daemon/src/main.ts
+++ b/packages/daemon/src/main.ts
@@ -3,6 +3,7 @@ import { loadConfig, type DaemonConfig } from "./config.js";
 import { SerialPoller } from "./serial-poller.js";
 import { MockSerialPoller } from "./mock-serial-poller.js";
 import { SocketServer, type ReadingSource } from "./socket-server.js";
+import { TC4ArduinoAdapter } from "./adapters/tc4-arduino.js";
 
 interface CliArgs {
   configPath: string | undefined;
@@ -45,7 +46,8 @@ function makeSource(cfg: DaemonConfig, log: ReturnType<typeof makeLogger>): Read
     log("info", "using_mock_serial", {});
     return new MockSerialPoller(cfg, log);
   }
-  return new SerialPoller(cfg, log);
+  const adapter = new TC4ArduinoAdapter(cfg);
+  return new SerialPoller(cfg, adapter, log);
 }
 
 async function main(): Promise<void> {

--- a/packages/daemon/src/serial-poller.ts
+++ b/packages/daemon/src/serial-poller.ts
@@ -8,6 +8,8 @@ import type {
   SensorFaultMessage,
 } from "@starmaya/shared";
 import { intervalMs, readTimeoutMs, type DaemonConfig } from "./config.js";
+import type { DeviceAdapter } from "./adapters/types.js";
+import { TC4ArduinoAdapter } from "./adapters/tc4-arduino.js";
 
 /**
  * Owns the serial port and runs the polling loop. Emits typed events that the
@@ -40,6 +42,7 @@ export class SerialPoller extends EventEmitter {
   private reconnectTimer: NodeJS.Timeout | null = null;
   private loopTimer: NodeJS.Timeout | null = null;
   private stopped = false;
+  private readonly adapter: DeviceAdapter;
 
   constructor(
     private readonly cfg: DaemonConfig,
@@ -47,6 +50,7 @@ export class SerialPoller extends EventEmitter {
   ) {
     super();
     this.reconnectDelayMs = cfg.reconnectBackoffInitialMs;
+    this.adapter = new TC4ArduinoAdapter(cfg);
   }
 
   /** Begin polling. Idempotent — calling twice has no additional effect. */
@@ -254,7 +258,8 @@ export class SerialPoller extends EventEmitter {
         reject(new Error(`read timeout after ${readTimeoutMs(this.cfg)}ms`));
       }, readTimeoutMs(this.cfg));
       this.pending = { resolve, reject, timer };
-      this.port.write("READ\r\n", (err) => {
+      const cmd = this.adapter.getPollCommand!();
+      this.port.write(cmd, (err) => {
         if (err) {
           this.failPending(err);
         }
@@ -281,53 +286,38 @@ export class SerialPoller extends EventEmitter {
   // ── Response handling ─────────────────────────────────────────────
 
   /**
-   * Parse a line and emit the appropriate message. Returns the parsed
-   * reading on success, throws on transport-level failure (which the caller
-   * already catches).
+   * Delegate line parsing to the adapter, then stamp `ts` and emit the
+   * appropriate event. Adapter returning `null` means malformed — log and
+   * drop, preserving prior behavior.
    */
   private handleReading(line: string): void {
     const ts = Date.now();
-    const fields = line.trim().split(",");
-    if (fields.length < 2) {
+    const parsed = this.adapter.parse(line);
+    if (parsed === null) {
       this.log("warn", "malformed_response", { line });
       return;
     }
-
-    const btRaw = parseFloat(fields[1]!);
-    const fault = classifyBtFault(btRaw, this.cfg);
-    if (fault) {
-      const msg: SensorFaultMessage = {
-        type: "sensor_fault",
-        ts,
-        raw: line,
-        reason: fault,
-      };
-      this.emit("sensor_fault", msg);
-      return;
+    switch (parsed.kind) {
+      case "reading": {
+        const msg: ReadingMessage = {
+          type: "reading",
+          ts,
+          bt_c: parsed.bt_c,
+          et_c: parsed.et_c,
+        };
+        this.emit("reading", msg);
+        return;
+      }
+      case "fault": {
+        const msg: SensorFaultMessage = {
+          type: "sensor_fault",
+          ts,
+          raw: parsed.raw,
+          reason: parsed.reason,
+        };
+        this.emit("sensor_fault", msg);
+        return;
+      }
     }
-
-    const etRaw = fields[2] !== undefined ? parseFloat(fields[2]) : NaN;
-    const etC = Number.isFinite(etRaw) ? etRaw : null;
-
-    const msg: ReadingMessage = {
-      type: "reading",
-      ts,
-      bt_c: btRaw,
-      et_c: etC,
-    };
-    this.emit("reading", msg);
   }
-}
-
-/**
- * Classify a BT value against MAX31855 error codes and the configured
- * plausibility range. Returns a fault reason or null if the value is OK.
- */
-function classifyBtFault(bt: number, cfg: DaemonConfig): string | null {
-  if (Number.isNaN(bt)) return "bt_nan";
-  if (bt === -1) return "bt_open_circuit";
-  if (bt === -2) return "bt_short_gnd";
-  if (bt === -3) return "bt_short_vcc";
-  if (bt < cfg.btMinPlausibleC || bt > cfg.btMaxPlausibleC) return "bt_out_of_range";
-  return null;
 }

--- a/packages/daemon/src/serial-poller.ts
+++ b/packages/daemon/src/serial-poller.ts
@@ -9,12 +9,20 @@ import type {
 } from "@starmaya/shared";
 import { intervalMs, readTimeoutMs, type DaemonConfig } from "./config.js";
 import type { DeviceAdapter } from "./adapters/types.js";
-import { TC4ArduinoAdapter } from "./adapters/tc4-arduino.js";
 
 /**
- * Owns the serial port and runs the polling loop. Emits typed events that the
- * socket server forwards to connected clients. Implements the state machine
+ * Owns the serial port, runs the polling/read loop, and emits typed events
+ * that the socket server forwards to clients. Implements the state machine
  * documented in docs/daemon-internals.md.
+ *
+ * Protocol semantics live in an injected {@link DeviceAdapter}; this class
+ * is intentionally hardware-agnostic. It supports two adapter modes:
+ *
+ *   - `request-response`: poller drives the cadence, writes
+ *     `adapter.getPollCommand()` each tick and feeds the reply line to
+ *     `adapter.parse()`.
+ *   - `streaming`: device drives the cadence; every received line is
+ *     forwarded to `adapter.parse()` directly.
  *
  * Events:
  *   - "reading"       (msg: ReadingMessage)
@@ -42,15 +50,14 @@ export class SerialPoller extends EventEmitter {
   private reconnectTimer: NodeJS.Timeout | null = null;
   private loopTimer: NodeJS.Timeout | null = null;
   private stopped = false;
-  private readonly adapter: DeviceAdapter;
 
   constructor(
     private readonly cfg: DaemonConfig,
+    private readonly adapter: DeviceAdapter,
     private readonly log: (level: string, msg: string, extra?: object) => void,
   ) {
     super();
     this.reconnectDelayMs = cfg.reconnectBackoffInitialMs;
-    this.adapter = new TC4ArduinoAdapter(cfg);
   }
 
   /** Begin polling. Idempotent — calling twice has no additional effect. */
@@ -110,26 +117,46 @@ export class SerialPoller extends EventEmitter {
     }
 
     // Port opened. Wait for the device to finish booting (Arduino Uno
-    // resets on DTR-on-open and takes ~1.5–2s to come back up) before
-    // confirming with a test READ.
+    // resets on DTR-on-open and takes ~1.5–2s to come back up). Devices
+    // that don't reset on open can configure postOpenDelayMs to 0.
     if (this.cfg.postOpenDelayMs > 0) {
       this.log("info", "post_open_delay", { delay_ms: this.cfg.postOpenDelayMs });
       await new Promise((resolve) => setTimeout(resolve, this.cfg.postOpenDelayMs));
       if (this.stopped) return;
     }
 
-    // Confirm with a test READ before declaring connected.
+    // Adapter-specific handshake (banner read, sample-rate config, etc.).
     try {
-      const reading = await this.pollOnce();
-      this.handleReading(reading);
-      this.setState("connected");
-      this.reconnectDelayMs = this.cfg.reconnectBackoffInitialMs; // reset backoff
-      this.scheduleNextPoll(intervalMs(this.cfg));
+      await this.adapter.onPortOpened?.();
     } catch (err) {
-      this.log("warn", "initial_read_failed", { error: (err as Error).message });
-      this.setState("disconnected", `initial_read_failed: ${(err as Error).message}`);
+      this.log("warn", "adapter_init_failed", { error: (err as Error).message });
+      this.setState("disconnected", `adapter_init_failed: ${(err as Error).message}`);
       this.closePort();
       this.scheduleReconnect();
+      return;
+    }
+    if (this.stopped) return;
+
+    if (this.adapter.mode === "request-response") {
+      // Confirm with a test poll before declaring connected.
+      try {
+        const reading = await this.pollOnce();
+        this.handleReading(reading);
+        this.setState("connected");
+        this.reconnectDelayMs = this.cfg.reconnectBackoffInitialMs; // reset backoff
+        this.scheduleNextPoll(intervalMs(this.cfg));
+      } catch (err) {
+        this.log("warn", "initial_read_failed", { error: (err as Error).message });
+        this.setState("disconnected", `initial_read_failed: ${(err as Error).message}`);
+        this.closePort();
+        this.scheduleReconnect();
+      }
+    } else {
+      // Streaming: port-open + onPortOpened succeeding is the strongest
+      // signal until real data arrives. Lines are processed as they come
+      // in via onLine().
+      this.setState("connected");
+      this.reconnectDelayMs = this.cfg.reconnectBackoffInitialMs;
     }
   }
 
@@ -244,6 +271,12 @@ export class SerialPoller extends EventEmitter {
   }
 
   private pollOnce(): Promise<string> {
+    // Local capture so TypeScript narrows the union across the closure.
+    // Only ever reached from request-response paths; the guard is defensive.
+    const adapter = this.adapter;
+    if (adapter.mode !== "request-response") {
+      return Promise.reject(new Error("pollOnce called on non-request-response adapter"));
+    }
     return new Promise((resolve, reject) => {
       if (!this.port || !this.parser) {
         reject(new Error("port not open"));
@@ -258,7 +291,7 @@ export class SerialPoller extends EventEmitter {
         reject(new Error(`read timeout after ${readTimeoutMs(this.cfg)}ms`));
       }, readTimeoutMs(this.cfg));
       this.pending = { resolve, reject, timer };
-      const cmd = this.adapter.getPollCommand!();
+      const cmd = adapter.getPollCommand();
       this.port.write(cmd, (err) => {
         if (err) {
           this.failPending(err);
@@ -268,7 +301,17 @@ export class SerialPoller extends EventEmitter {
   }
 
   private onLine(line: string): void {
-    if (!this.pending) return; // unsolicited line; ignore
+    if (this.adapter.mode === "streaming") {
+      // Drop lines arriving before we've declared connected, so emit
+      // ordering stays predictable for clients (device_status:connected
+      // is always the first thing they see after hello).
+      if (this.state !== "connected") return;
+      this.handleReading(line);
+      return;
+    }
+    // Request-response: resolve the in-flight read if any. Unsolicited
+    // lines (no pending) are dropped.
+    if (!this.pending) return;
     const p = this.pending;
     this.pending = null;
     clearTimeout(p.timer);


### PR DESCRIPTION
## Summary

Refactors the daemon so serial transport/lifecycle is fully separated from hardware-protocol semantics. The serial poller becomes a protocol-agnostic transport manager; all TC4 + MAX31855 + Arduino specifics live in `TC4ArduinoAdapter`. Adding a new device (ESP32, Phidgets, etc.) now requires only an adapter implementation and a one-line bootstrap edit — `serial-poller.ts` is never touched.

Behavior is preserved 1:1: same poll cadence, same emitted message shapes, same reconnect semantics, same malformed-line ignore rules.

## What changed

- **New** `packages/daemon/src/adapters/types.ts` — `DeviceAdapter` discriminated union (`RequestResponseDeviceAdapter` | `StreamingDeviceAdapter`) with a `ParseResult` (`reading | fault | null`) return contract. The poller stamps `ts` and message `type`; the adapter owns the rest.
- **New** `packages/daemon/src/adapters/tc4-arduino.ts` — `TC4ArduinoAdapter` encapsulating the `READ\r\n` poll command, CSV parsing, BT/ET column indexing, and MAX31855 fault-sentinel classification.
- **Modified** `packages/daemon/src/serial-poller.ts` — accepts a `DeviceAdapter` via constructor; mode-branched port-open lifecycle (`postOpenDelayMs` → `adapter.onPortOpened?.()` → initial-poll-or-stream-connect); mode-branched `onLine` dispatch. No hardware-specific strings or sentinels remain.
- **Modified** `packages/daemon/src/main.ts` — `makeAdapter(cfg)` switch over `cfg.deviceProfile` with a `never`-typed default so missing cases are compile errors.
- **Modified** `packages/daemon/src/config.ts` — adds `DeviceProfile` type (currently just `"tc4"`) and the `deviceProfile` config field (defaults to `"tc4"`).
- Mock poller, socket server, ring buffer, and `@starmaya/shared` types are untouched.

## Phases (one commit per phase)

1. `ebba37c` — introduce `DeviceAdapter` interface (Phase 1)
2. `afbfd37` — extract TC4 protocol adapter; poller delegates parse + poll command (Phase 2)
3. `b5e1050` — constructor inject adapter; mode-branched lifecycle; discriminated-union types (Phase 3)
4. `9f250a1` — `deviceProfile` config + `makeAdapter` selection switch (Phase 4)

Phase 5 (mock-infra validation) and Phase 6 (final regression validation) produced no diffs — verification only.

## Test plan

- [x] `pnpm build` passes cleanly across all four packages
- [x] No `READ\r\n`, CSV split, or MAX31855 sentinels remain in `serial-poller.ts` (grep)
- [x] No `: any`, no widening casts, no degraded type safety (grep + tsc strict)
- [x] Mock-serial smoke: daemon starts, `hello` + 1Hz `reading` stream over Unix socket has unchanged wire format
- [x] Real-serial startup smoke (against a missing device): `device_adapter_selected {profile: "tc4"}` logs, then expected `port_open_failed` + exponential reconnect backoff
- [x] `TC4ArduinoAdapter.parse()` produces the same `ParseResult` for every previously-tested case: valid 2-col, valid 3-col, CRLF-terminated, `-1`/`-2`/`-3` sentinels, NaN BT, out-of-range BT, malformed (<2 cols), empty line
- [ ] **Manual on-hardware verification still pending** — needs a live roast with the actual TC4 Arduino rig to confirm end-to-end behavior under real serial conditions

## Architecture validation

> *Can a developer add an ESP32 or Phidgets adapter without modifying `serial-poller.ts`?*

Yes. New adapter file + one line added to `DeviceProfile` union + one `case` in `makeAdapter`. The poller is fully protocol-agnostic.